### PR TITLE
deleted if the user does not possess the item

### DIFF
--- a/Store/src/database/database.cs
+++ b/Store/src/database/database.cs
@@ -91,6 +91,15 @@ public static class Database
                     PRIMARY KEY (id)
                 );", transaction: transaction);
 
+            await connection.ExecuteAsync($@"
+                DELETE FROM {equipTableName}
+                    WHERE NOT EXISTS (
+                    SELECT 1 FROM store_items
+                    WHERE store_items.Type = {equipTableName}.Type
+                    AND store_items.UniqueId = {equipTableName}.UniqueId
+                    AND store_items.SteamID = {equipTableName}.SteamID
+                )", transaction: transaction);
+
             await transaction.CommitAsync();
         }
         catch (Exception)


### PR DESCRIPTION
When initializing, the content of the 'equip' table is deleted if the user does not possess the item. This is performed through a database query operation.