### PR TITLE
Updated Crash Module

### DIFF
--- a/Store_Modules/Store_CoinFlip/cs2-store-coinflip.cs
+++ b/Store_Modules/Store_CoinFlip/cs2-store-coinflip.cs
@@ -73,7 +73,7 @@ public class Store_CoinFlipConfig : BasePluginConfig
 public class Store_CoinFlip : BasePlugin, IPluginConfig<Store_CoinFlipConfig>
 {
     public override string ModuleName => "Store Module [CoinFlip]";
-    public override string ModuleVersion => "0.0.1";
+    public override string ModuleVersion => "0.0.2";
     public override string ModuleAuthor => "Nathy & Schwarper";
 
     public IStoreApi? StoreApi { get; set; }
@@ -389,7 +389,7 @@ public class Store_CoinFlip : BasePlugin, IPluginConfig<Store_CoinFlipConfig>
         StoreApi.GivePlayerCredits(player, -credits);
         GlobalCoinFlip[option].Add(player, credits);
 
-        PrintToChatAll(Localizer["Join coinflip"], player.PlayerName, credits, Localizer[option]);
+        Server.PrintToChatAll(Localizer["Prefix"] + Localizer["Join coinflip", player.PlayerName, credits, Localizer[option]]);
     }
 
     [GameEventHandler(HookMode.Pre)]
@@ -402,7 +402,7 @@ public class Store_CoinFlip : BasePlugin, IPluginConfig<Store_CoinFlipConfig>
 
         if (Config.EnableCoinflipStartOfRound)
         {
-            PrintToChatAll(Localizer["Announce coinflip"]);
+            Server.PrintToChatAll(Localizer["Prefix"] + Localizer["Announce coinflip"]);
             Pay();
         }
 
@@ -454,7 +454,7 @@ public class Store_CoinFlip : BasePlugin, IPluginConfig<Store_CoinFlipConfig>
             throw new Exception("StoreApi could not be located.");
         }
 
-        PrintToChatAll(Localizer["Winner coinflip"], Localizer[option]);
+        Server.PrintToChatAll(Localizer["Prefix"] + Localizer["Winner coinflip", Localizer[option]]);
         Pay(option);
 
         winnerOption = option;
@@ -530,18 +530,5 @@ public class Store_CoinFlip : BasePlugin, IPluginConfig<Store_CoinFlipConfig>
             "Tails" => Config.Tails["multiplier"],
             _ => 1
         };
-    }
-
-    public void PrintToChatAll(string message, params object[] args)
-    {
-        foreach (CCSPlayerController player in Utilities.GetPlayers())
-        {
-            using (new WithTemporaryCulture(player.GetLanguage()))
-            {
-                StringBuilder builder = new(Localizer["Prefix"]);
-                builder.AppendFormat(Localizer[message], args);
-                player.PrintToChat(builder.ToString());
-            }
-        }
     }
 }

--- a/Store_Modules/Store_Crash/cs2-store-crash.cs
+++ b/Store_Modules/Store_Crash/cs2-store-crash.cs
@@ -1,4 +1,4 @@
-﻿using CounterStrikeSharp.API;
+using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Commands;
@@ -26,7 +26,29 @@ public class Store_CrashConfig : BasePluginConfig
     public float MultiplierIncrement { get; set; } = 0.01f;
 
     [JsonPropertyName("crash_commands")]
-    public List<string> CrashCommands { get; set; } = ["crash"];
+    public List<string> CrashCommands { get; set; } = new() { "crash" };
+
+    [JsonPropertyName("multiplier_ranges")]
+    public List<MultiplierRange> MultiplierRanges { get; set; } = new()
+    {
+        new MultiplierRange { Start = 1.0f, End = 2.0f, Chance = 55 },
+        new MultiplierRange { Start = 2.0f, End = 3.0f, Chance = 25 },
+        new MultiplierRange { Start = 3.0f, End = 4.0f, Chance = 10 },
+        new MultiplierRange { Start = 4.0f, End = 5.0f, Chance = 7 },
+        new MultiplierRange { Start = 5.0f, End = 15.0f, Chance = 3 }
+    };
+}
+
+public class MultiplierRange
+{
+    [JsonPropertyName("start")]
+    public float Start { get; set; }
+
+    [JsonPropertyName("end")]
+    public float End { get; set; }
+
+    [JsonPropertyName("chance")]
+    public int Chance { get; set; }
 }
 
 public class CrashGame
@@ -52,7 +74,7 @@ public class CrashGame
 public class Store_Crash : BasePlugin, IPluginConfig<Store_CrashConfig>
 {
     public override string ModuleName => "Store Module [Crash]";
-    public override string ModuleVersion => "0.0.1";
+    public override string ModuleVersion => "0.1.0";
     public override string ModuleAuthor => "Nathy";
 
     private readonly Random random = new();
@@ -183,26 +205,18 @@ public class Store_Crash : BasePlugin, IPluginConfig<Store_CrashConfig>
     private float SimulateCrashMultiplier()
     {
         int randomNumber = random.Next(1, 101);
+        int accumulatedChance = 0;
 
-        if (randomNumber <= 80)
+        foreach (var range in Config.MultiplierRanges)
         {
-            return (float)Math.Round(1.0 + random.NextDouble(), 2);
+            accumulatedChance += range.Chance;
+
+            if (randomNumber <= accumulatedChance)
+            {
+                return (float)Math.Round(range.Start + random.NextDouble() * (range.End - range.Start), 2);
+            }
         }
-        else if (randomNumber <= 90)
-        {
-            return (float)Math.Round(2.0 + random.NextDouble(), 2);
-        }
-        else if (randomNumber <= 95)
-        {
-            return (float)Math.Round(3.0 + random.NextDouble(), 2);
-        }
-        else if (randomNumber <= 99)
-        {
-            return (float)Math.Round(5.0 + random.NextDouble(), 2);
-        }
-        else
-        {
-            return (float)Math.Round(6.0 + random.NextDouble() * 10, 2);
-        }
+
+        return Config.MultiplierRanges.Last().End;
     }
 }

--- a/Store_Modules/Store_Crash/cs2-store-crash.cs
+++ b/Store_Modules/Store_Crash/cs2-store-crash.cs
@@ -26,7 +26,7 @@ public class Store_CrashConfig : BasePluginConfig
     public float MultiplierIncrement { get; set; } = 0.01f;
 
     [JsonPropertyName("crash_commands")]
-    public List<string> CrashCommands { get; set; } = new() { "crash" };
+    public List<string> CrashCommands { get; set; } = ["crash"];
 
     [JsonPropertyName("multiplier_ranges")]
     public List<MultiplierRange> MultiplierRanges { get; set; } = new()

--- a/Store_Modules/Store_Roulette/cs2-store-roulette.cs
+++ b/Store_Modules/Store_Roulette/cs2-store-roulette.cs
@@ -184,7 +184,7 @@ public class Store_Roulette : BasePlugin, IPluginConfig<Store_RouletteConfig>
         GlobalRoulette[color].Add(player, credits);
 
         char chatcolor = FindChatColor(color);
-        PrintToChatAll("Join roulette", player.PlayerName, credits, chatcolor, Localizer[color.Name]);
+        Server.PrintToChatAll(Localizer["Prefix"] + Localizer["Join roulette", player.PlayerName, credits, chatcolor, Localizer[color.Name]]);
     }
 
     [GameEventHandler(HookMode.Pre)]
@@ -237,7 +237,7 @@ public class Store_Roulette : BasePlugin, IPluginConfig<Store_RouletteConfig>
 
         char chatcolor = FindChatColor(color);
 
-        PrintToChatAll("Winner roulette", chatcolor, Localizer[color.Name]);
+        Server.PrintToChatAll(Localizer["Prefix"] + Localizer["Winner roulette", chatcolor, Localizer[color.Name]]);
         Pay(color);
 
         foreach (Color colorx in Colors)
@@ -310,18 +310,5 @@ public class Store_Roulette : BasePlugin, IPluginConfig<Store_RouletteConfig>
             KnownColor.Green => Config.Green["multiplier"],
             _ => ChatColors.White
         };
-    }
-
-    public void PrintToChatAll(string message, params object[] args)
-    {
-        foreach (CCSPlayerController player in Utilities.GetPlayers())
-        {
-            using (new WithTemporaryCulture(player.GetLanguage()))
-            {
-                StringBuilder builder = new(Localizer["Prefix"]);
-                builder.AppendFormat(Localizer[message], args);
-                player.PrintToChat(builder.ToString());
-            }
-        }
     }
 }

--- a/Store_Modules/Store_Roulette/cs2-store-roulette.cs
+++ b/Store_Modules/Store_Roulette/cs2-store-roulette.cs
@@ -48,7 +48,7 @@ public class Store_RouletteConfig : BasePluginConfig
 public class Store_Roulette : BasePlugin, IPluginConfig<Store_RouletteConfig>
 {
     public override string ModuleName => "[Store Module] Roulette";
-    public override string ModuleVersion => "0.0.3";
+    public override string ModuleVersion => "0.0.4";
     public override string ModuleAuthor => "schwarper";
 
     public IStoreApi? StoreApi { get; set; }


### PR DESCRIPTION
Make multiplier chances and ranges configurable in JSON.
Can be added as many as the configurator wants, but the chances must sum up to 100% in total. Default configuration:

```json
"multiplier_ranges": [
    {
      "start": 1.0,
      "end": 2.0,
      "chance": 55
    },
    {
      "start": 2.0,
      "end": 3.0,
      "chance": 25
    },
    {
      "start": 3.0,
      "end": 4.0,
      "chance": 10
    },
    {
      "start": 4.0,
      "end": 5.0,
      "chance": 7
    },
    {
      "start": 5.0,
      "end": 15.0,
      "chance": 3
    }
  ],
```

Explanation: 
```json
    {
      "start": 1.0,
      "end": 2.0,
      "chance": 55
    }
```
Above represents a 55% chance of multiplier crashing between 1.0 and 2.0