### PR TITLE
Fix menu display issues and enhance TagsApi error handling

### DIFF
--- a/Store/src/item/items/tags.cs
+++ b/Store/src/item/items/tags.cs
@@ -39,13 +39,31 @@ public static class Item_Tags
 
     public static void OnPluginsAllLoaded()
     {
-        _tagApi = ITagApi.Capability.Get() ?? throw new Exception("Tag API not found");
-
-        if (_othersExists)
-            _tagApi.OnMessageProcessPre += OnMessageProcess;
-
-        if (_scoreTagExists)
-            _tagApi.OnTagsUpdatedPre += OnTagsUpdatedPre;
+        try 
+        {
+            _tagApi = ITagApi.Capability.Get();
+            
+            if (_tagApi != null)
+            {
+                if (_othersExists)
+                    _tagApi.OnMessageProcessPre += OnMessageProcess;
+                
+                if (_scoreTagExists)
+                    _tagApi.OnTagsUpdatedPre += OnTagsUpdatedPre;
+                    
+                Console.WriteLine("[Store] TagsApi features successfully loaded");
+            }
+        }
+        catch (KeyNotFoundException)
+        {
+            Console.WriteLine("[Store] TagsApi plugin not found, tag features will be disabled");
+            _tagApi = null;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Store] Error loading TagsApi: {ex.Message}");
+            _tagApi = null;
+        }
     }
 
     private static void OnMapStart() { }

--- a/Store/src/menu/menu.cs
+++ b/Store/src/menu/menu.cs
@@ -19,6 +19,12 @@ public static class Menu
             return;
 
         string menutype = Config.Menu.MenuType.ToLower();
+        
+        try 
+        {
+            CS2ScreenMenuAPI.MenuAPI.CloseActiveMenu(player);
+        } 
+        catch {}
 
         switch (menutype)
         {

--- a/Store/src/menu/screentextmenu.cs
+++ b/Store/src/menu/screentextmenu.cs
@@ -20,10 +20,14 @@ public static class ScreenTextMenu
 
     public static void OpenMenu(CCSPlayerController player, string title, JsonElement elementData, bool inventory, ScreenMenu? mainMenu = null, ScreenMenu? parentMenu = null)
     {
+        bool isMainMenu = mainMenu == null && parentMenu == null;
+        
         ScreenMenu menu = new(title, Instance)
         {
             ParentMenu = parentMenu,
-            IsSubMenu = true
+            IsSubMenu = !isMainMenu,
+            PostSelectAction = CS2ScreenMenuAPI.Enums.PostSelectAction.Nothing,
+            MenuType = CS2ScreenMenuAPI.Enums.MenuType.Both
         };
 
         mainMenu ??= menu;


### PR DESCRIPTION
##CS2ScreenMenu
Fixed the issue where store menu required pressing the command twice to appear
Ensures any active menu is closed before opening a new menu
Added proper menu initialization settings

##Tagss:
Added proper handling for scenarios where TagsApi plugin is not present
Implemented graceful error catching mechanism to prevent plugin crashes due to missing TagsApi
Added informative logging for better diagnostics