### PR TITLE
This update is mainly to resolve compatibility issues with the CS2Fixes plugin

### DIFF
--- a/Store/src/config/config.cs
+++ b/Store/src/config/config.cs
@@ -147,7 +147,8 @@ public static class Config_Config
             ApplyPlayerskinDelay = float.Parse(settingsTable["ApplyPlayerskinDelay"].ToString()!),
             SellUsePurchaseCredit = bool.Parse(settingsTable["SellUsePurchaseCredit"].ToString()!),
             DefaultModelDisableLeg = bool.Parse(settingsTable["DefaultModelDisableLeg"].ToString()!),
-            Model0Model1Flag = settingsTable["Model0Model1Flag"].ToString()!
+            Model0Model1Flag = settingsTable["Model0Model1Flag"].ToString()!,
+            EnableCS2Fixes = bool.Parse(settingsTable["EnableCS2Fixes"].ToString()!)
         };
     }
 
@@ -227,5 +228,6 @@ public static class Config_Config
         public bool SellUsePurchaseCredit { get; set; } = false;
         public bool DefaultModelDisableLeg { get; set; } = false;
         public string Model0Model1Flag { get; set; } = "@css/root";
+        public bool EnableCS2Fixes { get; set; } = false;
     }
 }

--- a/Store/src/cs2-store.cs
+++ b/Store/src/cs2-store.cs
@@ -11,7 +11,7 @@ namespace Store;
 public class Store : BasePlugin, IPluginConfig<Item_Config>
 {
     public override string ModuleName => "Store";
-    public override string ModuleVersion => "2.10";
+    public override string ModuleVersion => "2.11";
     public override string ModuleAuthor => "schwarper";
 
     public Item_Config Config { get; set; } = new();

--- a/Store/src/cs2-store.cs
+++ b/Store/src/cs2-store.cs
@@ -11,7 +11,7 @@ namespace Store;
 public class Store : BasePlugin, IPluginConfig<Item_Config>
 {
     public override string ModuleName => "Store";
-    public override string ModuleVersion => "2.11";
+    public override string ModuleVersion => "2.12";
     public override string ModuleAuthor => "schwarper";
 
     public Item_Config Config { get; set; } = new();

--- a/Store/src/playerutils/playerutils.cs
+++ b/Store/src/playerutils/playerutils.cs
@@ -27,6 +27,11 @@ public static class PlayerUtils
                 return;
             }
 
+            if (Config.Settings.EnableCS2Fixes && player.TeamNum == (int)CsTeam.Terrorist)
+            {
+                return;
+            }
+
             player.PlayerPawn.Value?.ChangeModel(model, disableLeg, skin);
         }, TimerFlags.STOP_ON_MAPCHANGE);
     }
@@ -34,6 +39,11 @@ public static class PlayerUtils
     public static void ChangeModel(this CCSPlayerPawn pawn, string model, bool disableLeg, string? skin)
     {
         if (string.IsNullOrEmpty(model)) return;
+
+        if (Config.Settings.EnableCS2Fixes && pawn.TeamNum == (int)CsTeam.Terrorist)
+        {
+            return;
+        }
 
         Server.NextFrame(() =>
         {

--- a/config-example.toml
+++ b/config-example.toml
@@ -51,3 +51,4 @@ ApplyPlayerskinDelay = 0.6
 SellUsePurchaseCredit = false # If true, the selling ratio is calculated based on the price at which you bought the item. If false, it is calculated based on the current store price.
 DefaultModelDisableLeg = false
 Model0Model1Flag = "@css/root"
+EnableCS2Fixes = false # Set to true to enable CS2Fixes compatibility, false to disable


### PR DESCRIPTION
**💡 Note from 小彩旗:**

* ✅ It is recommended to enable this option when using the **CS2Fixes plugin**.
* 🔄 When **CS2Fixes compatibility** is enabled, the **store plugin will no longer handle model changes for Terrorist team players**.
* 🛠 You need to set `[DefaultModels]` `Terrorist` to empty when this mode is enabled.
* ⚠ For users upgrading from older versions, add `EnableCS2Fixes = false` at the end of `config.toml`.