### PR TITLE
add Wings item

### DIFF
--- a/Store/src/item/items/wings.cs
+++ b/Store/src/item/items/wings.cs
@@ -1,0 +1,144 @@
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
+using Store.Extension;
+using static Store.Store;
+using static StoreApi.Store;
+
+namespace Store;
+
+[StoreItemType("wings")]
+public class Item_Wings : IItemModule
+{
+    public bool Equipable => true;
+    public bool? RequiresAlive => null;
+
+    private static readonly Dictionary<CCSPlayerController, Dictionary<int, CDynamicProp>> PlayerWingsEntities = [];
+
+    public void OnPluginStart()
+    {
+        if (Item.IsAnyItemExistInType("wings"))
+        {
+            Instance.RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawn);
+            Instance.RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
+            Instance.RegisterEventHandler<EventPlayerDisconnect>(OnPlayerDisconnect);
+        }
+    }
+
+    public void OnMapStart()
+    {
+        PlayerWingsEntities.Clear();
+    }
+
+    public void OnServerPrecacheResources(ResourceManifest manifest)
+    {
+        var items = Item.GetItemsByType("wings");
+        foreach (var item in items)
+        {
+            if (item.Value.TryGetValue("model", out var model) && !string.IsNullOrEmpty(model))
+                manifest.AddResource(model);
+        }
+    }
+
+    public bool OnEquip(CCSPlayerController player, Dictionary<string, string> item)
+    {
+        if (!item.TryGetValue("slot", out var slotStr) || !int.TryParse(slotStr, out var slot) || slot < 0)
+            return false;
+        EquipWings(player, item["model"], slot);
+        return true;
+    }
+
+    public bool OnUnequip(CCSPlayerController player, Dictionary<string, string> item, bool update)
+    {
+        if (!item.TryGetValue("slot", out var slotStr) || !int.TryParse(slotStr, out var slot))
+            return false;
+        UnEquipWings(player, slot);
+        return true;
+    }
+
+    public static void EquipWings(CCSPlayerController player, string model, int slot)
+    {
+        UnEquipWings(player, slot);
+        Server.NextFrame(() =>
+        {
+            var entity = CreateWings(player, model);
+            if (entity != null && entity.IsValid)
+            {
+                if (!PlayerWingsEntities.ContainsKey(player))
+                    PlayerWingsEntities[player] = [];
+                PlayerWingsEntities[player][slot] = entity;
+            }
+        });
+    }
+
+    public static void UnEquipWings(CCSPlayerController player, int slot)
+    {
+        if (!PlayerWingsEntities.TryGetValue(player, out var value) || !value.ContainsKey(slot))
+            return;
+        var entity = value[slot];
+        if (entity != null && entity.IsValid)
+            entity.Remove();
+        value.Remove(slot);
+        if (value.Count == 0)
+            PlayerWingsEntities.Remove(player);
+    }
+
+    public static CDynamicProp? CreateWings(CCSPlayerController player, string model)
+    {
+        var pawn = player.PlayerPawn.Value;
+        if (pawn == null) return null;
+        var entity = Utilities.CreateEntityByName<CDynamicProp>("prop_dynamic_override");
+        if (entity == null) return null;
+        entity.CBodyComponent!.SceneNode!.Owner!.Entity!.Flags &= ~(uint)(1 << 2);
+        entity.SetModel(model);
+        entity.DispatchSpawn();
+        entity.AcceptInput("FollowEntity", pawn, pawn, "!activator");
+        var origin = pawn.AbsOrigin;
+        if (origin != null)
+        {
+            var offset = new Vector(0, 0, 0);
+            entity.Teleport(origin + offset, pawn.EyeAngles, pawn.AbsVelocity);
+        }
+        return entity;
+    }
+
+    public HookResult OnPlayerSpawn(EventPlayerSpawn @event, GameEventInfo info)
+    {
+        var player = @event.Userid;
+        if (player == null) return HookResult.Continue;
+        var wings = Item.GetPlayerEquipments(player, "wings");
+        foreach (var equip in wings)
+        {
+            var item = Item.GetItem(equip.UniqueId);
+            if (item != null && item.TryGetValue("model", out var model))
+            {
+                EquipWings(player, model, equip.Slot);
+            }
+        }
+        return HookResult.Continue;
+    }
+
+    public HookResult OnPlayerTeam(EventPlayerTeam @event, GameEventInfo info)
+    {
+        var player = @event.Userid;
+        if (player == null) return HookResult.Continue;
+        if (PlayerWingsEntities.ContainsKey(player))
+        {
+            foreach (var slot in PlayerWingsEntities[player].Keys.ToList())
+                UnEquipWings(player, slot);
+        }
+        return HookResult.Continue;
+    }
+
+    public HookResult OnPlayerDisconnect(EventPlayerDisconnect @event, GameEventInfo info)
+    {
+        var player = @event.Userid;
+        if (player == null) return HookResult.Continue;
+        if (PlayerWingsEntities.ContainsKey(player))
+        {
+            foreach (var slot in PlayerWingsEntities[player].Keys.ToList())
+                UnEquipWings(player, slot);
+        }
+        return HookResult.Continue;
+    }
+} 

--- a/cs2-store-example.json
+++ b/cs2-store-example.json
@@ -261,9 +261,9 @@
       }
     },
     "Wings": {
-      "Wings Test": {
+      "Wings hostage": {
         "uniqueid": "mywings",
-        "model": "characters/nozb1/wings/fortnite/devil_rock/wings_devil_rock.vmdl",
+        "model": "models/hostage/hostage_carry.vmdl",
         "type": "wings",
         "price": "1000",
         "slot": "1"

--- a/cs2-store-example.json
+++ b/cs2-store-example.json
@@ -260,6 +260,15 @@
         "slot": "1"
       }
     },
+    "Wings": {
+      "Wings Test": {
+        "uniqueid": "mywings",
+        "model": "characters/nozb1/wings/fortnite/devil_rock/wings_devil_rock.vmdl",
+        "type": "wings",
+        "price": "1000",
+        "slot": "1"
+      }
+    },
     "Tags": {
       "Chat Color": {
         "Red": {


### PR DESCRIPTION
## New Feature: Wings

The plugin now supports the Wings feature, allowing players to purchase and equip wing models as back accessories through the store.

- Supports multiple wing models; model path, name, price, etc. are fully customizable.
- Wings automatically follow the player and support multiple slots.
- Resources are automatically precached to ensure models load correctly.

**How to use:**
1. Add a wings item to your `cs2-store.json` configuration file, for example:
```json
"Wings": {
      "Wings hostage": {
        "uniqueid": "mywings",
        "model": "models/hostage/hostage_carry.vmdl",
        "type": "wings",
        "price": "1000",
        "slot": "1"
      }
    }
```
2. Reload the plugin or restart the server.
3. Players can then purchase and equip wings from the store menu.

> **Note:** To use the wings feature, you must add a wings item to your `cs2-store.json` file. Otherwise, the feature will not be available.