### PR TITLE
Fix EyeAngles

### DIFF
--- a/Store/src/item/items/playerskin.cs
+++ b/Store/src/item/items/playerskin.cs
@@ -198,9 +198,9 @@ public class Item_PlayerSkin : IItemModule
     public static Vector GetFrontPosition(Vector position, QAngle angles, float distance = 100.0f)
     {
         float radYaw = angles.Y * (MathF.PI / 180.0f);
-        // 计算玩家正前方的位置，稍微抬高一点避免模型陷入地面
+        // Calculate the position in front of the player, slightly elevated to avoid the model sinking into the ground
         Vector frontPos = position + new Vector(MathF.Cos(radYaw), MathF.Sin(radYaw), 0) * distance;
-        frontPos.Z += 10.0f; // 稍微抬高，避免模型陷入地面
+        frontPos.Z += 10.0f; // Slightly elevate to avoid the model sinking into the ground
         return frontPos;
     }
 }

--- a/Store/src/item/items/playerskin.cs
+++ b/Store/src/item/items/playerskin.cs
@@ -150,9 +150,7 @@ public class Item_PlayerSkin : IItemModule
         if (entity == null || !entity.IsValid || player.PlayerPawn.Value is not CCSPlayerPawn playerPawn)
             return;
 
-        // Since EyeAngles is not available, we'll use a default angle
-        // 0 degrees should place the model in front of the player
-        QAngle viewAngles = new QAngle(0, 0f, 0);
+        QAngle viewAngles = playerPawn.AbsRotation ?? new QAngle(0, 0, 0);
         Vector _origin = GetFrontPosition(playerPawn.AbsOrigin!, viewAngles);
         QAngle modelAngles = new(0, viewAngles.Y + 180, 0);
 
@@ -200,6 +198,9 @@ public class Item_PlayerSkin : IItemModule
     public static Vector GetFrontPosition(Vector position, QAngle angles, float distance = 100.0f)
     {
         float radYaw = angles.Y * (MathF.PI / 180.0f);
-        return position + new Vector(MathF.Cos(radYaw), MathF.Sin(radYaw), 0) * distance;
+        // 计算玩家正前方的位置，稍微抬高一点避免模型陷入地面
+        Vector frontPos = position + new Vector(MathF.Cos(radYaw), MathF.Sin(radYaw), 0) * distance;
+        frontPos.Z += 10.0f; // 稍微抬高，避免模型陷入地面
+        return frontPos;
     }
 }

--- a/Store/src/item/items/playerskin.cs
+++ b/Store/src/item/items/playerskin.cs
@@ -150,8 +150,11 @@ public class Item_PlayerSkin : IItemModule
         if (entity == null || !entity.IsValid || player.PlayerPawn.Value is not CCSPlayerPawn playerPawn)
             return;
 
-        Vector _origin = GetFrontPosition(playerPawn.AbsOrigin!, playerPawn.EyeAngles);
-        QAngle modelAngles = new(0, playerPawn.EyeAngles.Y + 180, 0);
+        // Since EyeAngles is not available, we'll use a default angle
+        // 0 degrees should place the model in front of the player
+        QAngle viewAngles = new QAngle(0, 0f, 0);
+        Vector _origin = GetFrontPosition(playerPawn.AbsOrigin!, viewAngles);
+        QAngle modelAngles = new(0, viewAngles.Y + 180, 0);
 
         entity.Spawnflags = 256u;
         entity.Collision.SolidType = SolidType_t.SOLID_VPHYSICS;


### PR DESCRIPTION
When I use the WASD menu and open Store -> Player Skins -> Preview, the console shows the following error message:
```20:55:22 [EROR] (cssharp:Core) Error invoking callback
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.MissingMethodException: Method not found: 'CounterStrikeSharp.API.Modules.Utils.QAngle CounterStrikeSharp.API.Core.CCSPlayerPawnBase.get_EyeAngles()'.
   at Store.Item_PlayerSkin.Inspect(CCSPlayerController player, String model, String skin)
   at Store.MenuBase.InspectAction(CCSPlayerController player, Dictionary`2 item, String type) in /home/runner/work/cs2-store/cs2-store/Store/src/menu/menubase.cs:line 60
   at Store.Menu.<>c__DisplayClass6_0.<AddInspectOption>b__0(CCSPlayerController p, ItemOption o) in /home/runner/work/cs2-store/cs2-store/Store/src/menu/menu.cs:line 199
   at CS2MenuManager.API.Class.BaseMenuInstance.HandleSelectAction(ItemOption menuOption) in /home/runner/work/CS2MenuManager/CS2MenuManager/CS2MenuManager/API/Class/BaseMenu.cs:line 277
   at CS2MenuManager.API.Menu.WasdMenuInstance.OnTick() in /home/runner/work/CS2MenuManager/CS2MenuManager/CS2MenuManager/API/Menu/WasdMenu.cs:line 179
   at InvokeStub_OnTick.Invoke(Object, Object, IntPtr*)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at CounterStrikeSharp.API.Core.BasePlugin.<>c__DisplayClass51_0`1.<RegisterListener>b__2(ScriptContext context) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/BasePlugin.cs:line 298
   at InvokeStub_Action`1.Invoke(Object, Span`1)
   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at CounterStrikeSharp.API.Core.FunctionReference.<CreateWrappedCallback>b__18_0(fxScriptContext* context)```