### PR TITLE
fix: restore customweapon support for animgraph2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 # Ignore everything in BuildOutput directory
 BuildOutput/
+shared/

--- a/Store/src/cs2-store.cs
+++ b/Store/src/cs2-store.cs
@@ -13,7 +13,7 @@ namespace Store;
 public class Store : BasePlugin, IPluginConfig<Item_Config>
 {
     public override string ModuleName => "Store";
-    public override string ModuleVersion => "v24";
+    public override string ModuleVersion => "v25";
     public override string ModuleAuthor => "schwarper";
 
     public Item_Config Config { get; set; } = new();
@@ -82,4 +82,5 @@ public class Store : BasePlugin, IPluginConfig<Item_Config>
         Config = config;
     }
 }
+
 

--- a/Store/src/event/event.cs
+++ b/Store/src/event/event.cs
@@ -142,7 +142,7 @@ public static class Event
     {
         Item_Smoke.OnEntityCreated(entity);
         Item_GrenadeTrail.OnEntityCreated(entity);
-        //Item_CustomWeapon.OnEntityCreated(entity);
+        Item_CustomWeapon.OnEntityCreated(entity);
     }
 
     private static void OnClientAuthorized(int playerSlot, SteamID steamId)

--- a/Store/src/item/item.cs
+++ b/Store/src/item/item.cs
@@ -86,6 +86,14 @@ public static class Item
 
     public static bool Purchase(CCSPlayerController player, Dictionary<string, string> item)
     {
+        if (Instance.GlobalStorePlayerItems.Any(p =>
+                p.SteamID == player.SteamID &&
+                p.Type == item["type"] &&
+                p.UniqueId == item["uniqueid"]))
+        {
+            return false;
+        }
+
         if (Credits.Get(player) < int.Parse(item["price"]))
         {
             player.PrintToChatMessage("No credits enough");

--- a/Store/src/item/item.cs
+++ b/Store/src/item/item.cs
@@ -209,10 +209,10 @@ public static class Item
                     return false;
                 
                 Dictionary<string, string>? equippedItem = GetItem(p.UniqueId);
-                return equippedItem != null && 
+                return equippedItem != null &&
                        equippedItem.TryGetValue("weapon", out string? equippedWeapon) &&
                        item.TryGetValue("weapon", out string? newWeapon) &&
-                       equippedWeapon == newWeapon;
+                       SameWeaponBase(equippedWeapon, newWeapon);
             })],
 
             "equipment" => [.. Instance.GlobalStorePlayerEquipments.FindAll(p =>
@@ -225,6 +225,25 @@ public static class Item
                 p.Type == itemType &&
                 p.Slot == int.Parse(item["slot"]))]
         };
+    }
+
+    private static bool SameWeaponBase(string equippedWeapon, string newWeapon)
+    {
+        if (string.IsNullOrEmpty(equippedWeapon) || string.IsNullOrEmpty(newWeapon))
+        {
+            return false;
+        }
+
+        string equippedBase = GetWeaponBase(equippedWeapon);
+        string newBase = GetWeaponBase(newWeapon);
+
+        return string.Equals(equippedBase, newBase, StringComparison.Ordinal);
+    }
+
+    private static string GetWeaponBase(string weaponSpec)
+    {
+        int idx = weaponSpec.IndexOf(':');
+        return idx > 0 ? weaponSpec[..idx] : weaponSpec;
     }
 
     public static bool Unequip(CCSPlayerController player, Dictionary<string, string> item, bool update)

--- a/Store/src/item/items/customweapon.cs
+++ b/Store/src/item/items/customweapon.cs
@@ -219,6 +219,7 @@ public class Item_CustomWeapon : IItemModule
             return (weaponDesignerName, weaponIndex) switch
             {
                 var (name, _) when name.Contains("bayonet") => "weapon_knife",
+                ("weapon_deagle", 64) => "weapon_revolver",
                 ("weapon_m4a1", 60) => "weapon_m4a1_silencer",
                 ("weapon_hkp2000", 61) => "weapon_usp_silencer",
                 ("weapon_mp7", 23) => "weapon_mp5sd",

--- a/Store/src/item/items/customweapon.cs
+++ b/Store/src/item/items/customweapon.cs
@@ -199,12 +199,15 @@ public class Item_CustomWeapon : IItemModule
 
     public class Weapon
     {
+        // Summary: Legacy viewmodel/worldmodel swapping is disabled; animgraph2 uses subclass changes instead.
+        /*
         public enum GlobalNameData
         {
             ViewModelDefault,
             ViewModel,
             WorldModel
         }
+        */
 
         private static readonly Dictionary<nint, string> OldSubclassByHandle = new();
 
@@ -240,6 +243,7 @@ public class Item_CustomWeapon : IItemModule
             return !string.IsNullOrEmpty(weaponName) && !string.IsNullOrEmpty(weaponSubclass);
         }
 
+        /*
         public static string GetFromGlobalName(string globalName, GlobalNameData data)
         {
             string[] globalNameSplit = globalName.Split(',');
@@ -267,6 +271,7 @@ public class Item_CustomWeapon : IItemModule
                 SetViewModel(player, oldModel);
             }
         }
+        */
 
         public static bool HandleEquip(CCSPlayerController player, Dictionary<string, string> item, bool isEquip)
         {
@@ -305,6 +310,7 @@ public class Item_CustomWeapon : IItemModule
                 : (weaponServices.MyWeapons.SingleOrDefault(p => p.Value != null && GetDesignerName(p.Value) == weaponName)?.Value);
         }
 
+        /*
         public static string GetViewModel(CCSPlayerController player)
         {
             var entity = ViewModel(player);
@@ -348,7 +354,9 @@ public class Item_CustomWeapon : IItemModule
                 SetViewModel(player, model);
             }
         }
+        */
 
+        // Summary: Animgraph2 uses ChangeSubclass; keep subclass-based apply path.
         public static void SetSubclass(CBasePlayerWeapon weapon, string oldSubclass, string newSubclass)
         {
             if (string.IsNullOrEmpty(newSubclass))
@@ -373,6 +381,7 @@ public class Item_CustomWeapon : IItemModule
             OldSubclassByHandle.Remove(handle);
         }
 
+        /*
         private static CBaseEntity? ViewModel(CCSPlayerController player)
         {
             var pawn = player.PlayerPawn.Value;
@@ -389,6 +398,7 @@ public class Item_CustomWeapon : IItemModule
 
             return new CHandle<CBaseEntity>(handle).Value;
         }
+        */
     }
 
     public static void Inspect(CCSPlayerController player, string weapon)

--- a/Store/src/item/items/customweapon.cs
+++ b/Store/src/item/items/customweapon.cs
@@ -1,4 +1,3 @@
-﻿/*
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Memory;
@@ -42,17 +41,6 @@ public class Item_CustomWeapon : IItemModule
 
     public void OnServerPrecacheResources(ResourceManifest manifest)
     {
-        List<KeyValuePair<string, Dictionary<string, string>>> items = Item.GetItemsByType("customweapon");
-
-        foreach (KeyValuePair<string, Dictionary<string, string>> item in items)
-        {
-            manifest.AddResource(item.Value["viewmodel"]);
-
-            if (item.Value.TryGetValue("worldmodel", out string? worldmodel) && !string.IsNullOrEmpty(worldmodel))
-            {
-                manifest.AddResource(worldmodel);
-            }
-        }
     }
 
     public bool OnEquip(CCSPlayerController player, Dictionary<string, string> item)
@@ -143,14 +131,18 @@ public class Item_CustomWeapon : IItemModule
         string weaponDesignerName, EntityType entityType, CCSPlayerController player)
     {
         Dictionary<string, string>? itemData = Item.GetItem(equipment.UniqueId);
-        if (itemData == null || !weaponDesignerName.Contains(itemData["weapon"])) return;
+        if (itemData == null) return;
 
-        itemData.TryGetValue("worldmodel", out string? worldModel);
-        worldModel = string.IsNullOrEmpty(worldModel) ? itemData["viewmodel"] : worldModel;
+        if (!Weapon.TryParseWeaponSpec(itemData["weapon"], out string weaponBase, out string weaponSubclass))
+        {
+            return;
+        }
+
+        if (!weaponDesignerName.Equals(weaponBase, StringComparison.Ordinal)) return;
 
         try
         {
-            ApplyModelToEntity(entity, entityType, player, itemData["viewmodel"], worldModel);
+            ApplyModelToEntity(entity, entityType, player, weaponBase, weaponSubclass);
         }
         catch (Exception ex)
         {
@@ -159,7 +151,7 @@ public class Item_CustomWeapon : IItemModule
     }
 
     private static void ApplyModelToEntity(CEntityInstance entity, EntityType entityType,
-        CCSPlayerController player, string viewModel, string worldModel)
+        CCSPlayerController player, string weaponBase, string weaponSubclass)
     {
         switch (entityType)
         {
@@ -167,16 +159,10 @@ public class Item_CustomWeapon : IItemModule
                 CBasePlayerWeapon weapon = entity.As<CBasePlayerWeapon>();
                 if (weapon?.IsValid != true || weapon.OriginalOwnerXuidLow <= 0) return;
 
-                CBasePlayerWeapon? activeWeapon = player.PlayerPawn.Value?.WeaponServices?.ActiveWeapon.Value;
-                Weapon.UpdateModel(player, weapon, viewModel, worldModel, weapon == activeWeapon);
+                Weapon.SetSubclass(weapon, weaponBase, weaponSubclass);
                 break;
 
             case EntityType.Projectile:
-                CBaseCSGrenadeProjectile projectile = entity.As<CBaseCSGrenadeProjectile>();
-                if (projectile?.IsValid == true)
-                {
-                    projectile.SetModel(worldModel);
-                }
                 break;
         }
     }
@@ -186,11 +172,26 @@ public class Item_CustomWeapon : IItemModule
         CCSPlayerController? player = @event.Userid;
         if (player == null) return HookResult.Continue;
 
-        string? globalName = player.PlayerPawn.Value?.WeaponServices?.ActiveWeapon.Value?.Globalname;
-        if (!string.IsNullOrEmpty(globalName))
+        CBasePlayerWeapon? activeWeapon = player.PlayerPawn.Value?.WeaponServices?.ActiveWeapon.Value;
+        if (activeWeapon?.IsValid != true) return HookResult.Continue;
+
+        string weaponDesignerName = Weapon.GetDesignerName(activeWeapon);
+
+        List<StoreApi.Store.Store_Equipment> playerEquipments = Item.GetPlayerEquipments(player, "customweapon");
+        foreach (StoreApi.Store.Store_Equipment equipment in playerEquipments)
         {
-            string model = Weapon.GetFromGlobalName(globalName, Weapon.GlobalNameData.ViewModel);
-            Weapon.SetViewModel(player, model);
+            Dictionary<string, string>? itemData = Item.GetItem(equipment.UniqueId);
+            if (itemData == null) continue;
+
+            if (!Weapon.TryParseWeaponSpec(itemData["weapon"], out string weaponBase, out string weaponSubclass))
+            {
+                continue;
+            }
+
+            if (!weaponDesignerName.Equals(weaponBase, StringComparison.Ordinal)) continue;
+
+            Weapon.SetSubclass(activeWeapon, weaponBase, weaponSubclass);
+            break;
         }
 
         return HookResult.Continue;
@@ -205,6 +206,8 @@ public class Item_CustomWeapon : IItemModule
             WorldModel
         }
 
+        private static readonly Dictionary<nint, string> OldSubclassByHandle = new();
+
         public static string GetDesignerName(CBasePlayerWeapon weapon)
         {
             string weaponDesignerName = weapon.DesignerName;
@@ -218,6 +221,23 @@ public class Item_CustomWeapon : IItemModule
                 ("weapon_mp7", 23) => "weapon_mp5sd",
                 _ => weaponDesignerName
             };
+        }
+
+        public static bool TryParseWeaponSpec(string weaponSpec, out string weaponName, out string weaponSubclass)
+        {
+            weaponName = string.Empty;
+            weaponSubclass = string.Empty;
+
+            if (string.IsNullOrEmpty(weaponSpec))
+            {
+                return false;
+            }
+
+            string[] parts = weaponSpec.Split(':', 2);
+            weaponName = parts[0].Trim();
+            weaponSubclass = parts.Length > 1 ? parts[1].Trim() : string.Empty;
+
+            return !string.IsNullOrEmpty(weaponName) && !string.IsNullOrEmpty(weaponSubclass);
         }
 
         public static string GetFromGlobalName(string globalName, GlobalNameData data)
@@ -252,19 +272,21 @@ public class Item_CustomWeapon : IItemModule
         {
             if (player.PawnIsAlive)
             {
-                CBasePlayerWeapon? weapon = Get(player, item["weapon"]);
+                if (!TryParseWeaponSpec(item["weapon"], out string weaponBase, out string weaponSubclass))
+                {
+                    return true;
+                }
+
+                CBasePlayerWeapon? weapon = Get(player, weaponBase);
                 if (weapon != null)
                 {
-                    bool equip = weapon == player.PlayerPawn.Value?.WeaponServices?.ActiveWeapon.Value;
-
                     if (isEquip)
                     {
-                        item.TryGetValue("worldmodel", out string? worldModel);
-                        UpdateModel(player, weapon, item["viewmodel"], worldModel, equip);
+                        SetSubclass(weapon, weaponBase, weaponSubclass);
                     }
                     else
                     {
-                        ResetWeapon(player, weapon, equip);
+                        ResetSubclass(weapon);
                     }
                 }
             }
@@ -327,6 +349,30 @@ public class Item_CustomWeapon : IItemModule
             }
         }
 
+        public static void SetSubclass(CBasePlayerWeapon weapon, string oldSubclass, string newSubclass)
+        {
+            if (string.IsNullOrEmpty(newSubclass))
+            {
+                return;
+            }
+
+            var handle = weapon.Handle;
+            OldSubclassByHandle[handle] = oldSubclass;
+            weapon.AcceptInput("ChangeSubclass", weapon, weapon, newSubclass);
+        }
+
+        public static void ResetSubclass(CBasePlayerWeapon weapon)
+        {
+            var handle = weapon.Handle;
+            if (!OldSubclassByHandle.TryGetValue(handle, out string? oldSubclass) || string.IsNullOrEmpty(oldSubclass))
+            {
+                return;
+            }
+
+            weapon.AcceptInput("ChangeSubclass", weapon, weapon, oldSubclass);
+            OldSubclassByHandle.Remove(handle);
+        }
+
         private static CBaseEntity? ViewModel(CCSPlayerController player)
         {
             var pawn = player.PlayerPawn.Value;
@@ -345,28 +391,29 @@ public class Item_CustomWeapon : IItemModule
         }
     }
 
-    public static void Inspect(CCSPlayerController player, string model, string weapon)
+    public static void Inspect(CCSPlayerController player, string weapon)
     {
         if (player.PlayerPawn.Value?.WeaponServices?.ActiveWeapon.Value is not CBasePlayerWeapon activeWeapon) return;
 
-        if (Weapon.GetDesignerName(activeWeapon) != weapon)
+        if (!Weapon.TryParseWeaponSpec(weapon, out string weaponBase, out string weaponSubclass))
         {
-            player.PrintToChatMessage("You need correct weapon", weapon);
             return;
         }
 
-        string globalName = activeWeapon.Globalname;
-        string oldModel = !string.IsNullOrEmpty(globalName) ? Weapon.GetFromGlobalName(globalName, Weapon.GlobalNameData.ViewModel) : Weapon.GetViewModel(player);
+        if (Weapon.GetDesignerName(activeWeapon) != weaponBase)
+        {
+            player.PrintToChatMessage("You need correct weapon", weaponBase);
+            return;
+        }
 
-        Weapon.SetViewModel(player, model);
+        Weapon.SetSubclass(activeWeapon, weaponBase, weaponSubclass);
 
         Instance.AddTimer(3.0f, () =>
         {
             if (player.IsValid && player.PlayerPawn.Value.WeaponServices.ActiveWeapon.Value == activeWeapon)
             {
-                Weapon.SetViewModel(player, oldModel);
+                Weapon.ResetSubclass(activeWeapon);
             }
         });
     }
 }
-*/

--- a/Store/src/menu/menubase.cs
+++ b/Store/src/menu/menubase.cs
@@ -59,11 +59,9 @@ public static class MenuBase
                 item.TryGetValue("skin", out string? skn);
                 Item_PlayerSkin.Inspect(player, item["model"], skn);
                 break;
-                /*
             case "customweapon":
-                Item_CustomWeapon.Inspect(player, item["viewmodel"], item["weapon"]);
+                Item_CustomWeapon.Inspect(player, item["weapon"]);
                 break;
-                */
         }
     }
 

--- a/cs2-store-example.json
+++ b/cs2-store-example.json
@@ -239,17 +239,15 @@
       }
     },
     "Custom Weapon": {
-      "AK47": {
-        "Default AK47": {
-          "uniqueid": "defaultak47cw",
-          "viewmodel": "weapons/models/ak47/weapon_rif_ak47.vmdl",
-          "worldmodel": "",
-          "type": "customweapon",
-          "weapon": "weapon_ak47",
-          "price": "1000",
-          "slot": "1"
+        "AK47": {
+          "Default AK47": {
+            "uniqueid": "defaultak47cw",
+            "type": "customweapon",
+            "weapon": "weapon_ak47:weapon_ak47+1550",
+            "price": "1000",
+            "slot": "1"
+          }
         }
-      }
     },
     "Pet": {
       "Chicken": {


### PR DESCRIPTION
# Summary
This PR restores customweapon support for the animgraph2 (AG2) update by switching from direct model swapping to subclass-based weapon replacement.

---

### Changes

- Custom weapons now apply models via ChangeSubclass instead of viewmodel/worldmodel overrides.
- Equip/inspect paths parse base:subclass and apply the subclass only when the active weapon base matches.
- Conflicts are resolved per weapon base so only one skin is equipped per weapon.
- Legacy viewmodel/worldmodel helpers are commented out with notes since AG2 no longer uses them.

### How AG2 equipment works now

- Each custom weapon item uses weapon in the format `base:subclass` (e.g., weapon_knife:weapon_knife_karambit+1550).
- On entity creation and item equip, the plugin checks the player’s equipped items and calls ChangeSubclass for the matching base weapon.
- Inspect temporarily changes the active weapon’s subclass and then resets it.

### External weapon.vdata setup
To make AG2 models work, you must define subclasses in `weapons.vdata` (decomplie it form valve's pak using Source2Viewer):

```code
   "weapon_knife_karambit+1550" = 
    {
        m_nKillAward = 1500
        m_nDamage = 50
        m_iMaxClip1 = 0
        m_iMaxClip2 = 0
        m_iDefaultClip1 = 1
        m_iDefaultClip2 = 1
        m_bAllowFlipping = true
        m_bBuiltRightHanded = true
        m_bIsFullAuto = false
        m_nNumBullets = 1
        m_bMeleeWeapon = true
        m_iWeight = 0
        m_iRumbleEffect = 9
        m_nPrimaryReserveAmmoMax = 0
        m_nSecondaryReserveAmmoMax = 0
        m_flInaccuracyJumpInitial = 0.000000
        m_flInaccuracyJumpApex = 0.000000
        m_flInaccuracyReload = 0.000000
        m_flDeployDuration = 1.000000
        m_flDisallowAttackAfterReloadStartDuration = 5.000000
        m_nSpreadSeed = 0
        m_flRecoveryTimeCrouch = 1.000000
        m_flRecoveryTimeStand = 1.000000
        m_flRecoveryTimeCrouchFinal = -1.000000
        m_flRecoveryTimeStandFinal = -1.000000
        m_nRecoveryTransitionStartBullet = 0
        m_nRecoveryTransitionEndBullet = 0
        m_flHeadshotMultiplier = 4.000000
        m_flArmorRatio = 1.700000
        m_flPenetration = 1.000000
        m_flFlinchVelocityModifierLarge = 0.300000
        m_flFlinchVelocityModifierSmall = 0.300000
        m_flRange = 4096.000000
        m_flRangeModifier = 0.990000
        m_eSilencerType = "WEAPONSILENCER_NONE"
        m_nCrosshairMinDistance = 7
        m_nCrosshairDeltaDistance = 3
        m_flAttackMovespeedFactor = 1.000000
        m_bUnzoomsAfterShot = false
        m_bHideViewModelWhenZoomed = false
        m_nZoomLevels = 0
        m_nZoomFOV1 = 90
        m_nZoomFOV2 = 90
        m_flZoomTime0 = 0.000000
        m_flZoomTime1 = 0.000000
        m_flZoomTime2 = 0.000000
        m_flInaccuracyPitchShift = 0.000000
        m_flInaccuracyAltSoundThreshold = 0.000000
        m_bHasBurstMode = false
        m_bIsRevolver = false
        m_bCannotShootUnderwater = false
        m_flCycleTime = 
        [
            0.150000,
            0.300000,
        ]
        m_flMaxSpeed = 
        [
            250.000000,
            250.000000,
        ]
        m_flSpread = 
        [
            0.000000,
            0.000000,
        ]
        m_flInaccuracyCrouch = 
        [
            0.000000,
            0.000000,
        ]
        m_flInaccuracyStand = 
        [
            0.000000,
            0.000000,
        ]
        m_flInaccuracyJump = 
        [
            0.000000,
            0.000000,
        ]
        m_flInaccuracyLand = 
        [
            0.000000,
            0.000000,
        ]
        m_flInaccuracyLadder = 
        [
            0.000000,
            0.000000,
        ]
        m_flInaccuracyFire = 
        [
            0.000000,
            0.000000,
        ]
        m_flInaccuracyMove = 
        [
            0.000000,
            0.000000,
        ]
        m_flRecoilAngle = 
        [
            0.000000,
            0.000000,
        ]
        m_flRecoilAngleVariance = 
        [
            0.000000,
            0.000000,
        ]
        m_flRecoilMagnitude = 
        [
            0.000000,
            0.000000,
        ]
        m_flRecoilMagnitudeVariance = 
        [
            0.000000,
            0.000000,
        ]
        m_nTracerFrequency = 0
        m_bAutoSwitchFrom = true
        m_bAutoSwitchTo = true
        _base = "507"
        taxonomy = 
        {
            weapon = true
            self_damage_on_miss__inflicts_damage = true
            melee = true
        }
        _class = "weapon_knife"
        m_GearSlot = "GEAR_SLOT_KNIFE"
        m_GearSlotPosition = 0
        m_DefaultLoadoutPosition = "LOADOUT_POSITION_MELEE"
        m_szWorldModel = resource_name:"phase2/weapons/models/aur1c/karambit_mfsn/karambit_mfsn_ag2.vmdl"
        m_WeaponType = "WEAPONTYPE_KNIFE"
        m_aShootSounds = 
        {
            WEAPON_SOUND_EMPTY = soundevent:"Default.ClipEmpty_Rifle"
            WEAPON_SOUND_SINGLE = soundevent:"Weapon_DEagle.Single"
            WEAPON_SOUND_RELOAD = soundevent:"Default.Reload"
            WEAPON_SOUND_NEARLYEMPTY = soundevent:"Default.nearlyempty"
        }
        m_nPrice = 0
        m_nRecoilSeed = 26701
        m_szModel_AG2 = resource_name:"phase2/weapons/models/aur1c/karambit_mfsn/karambit_mfsn_ag2.vmdl"
        m_szAnimSkeleton = resource_name:"animation/skeletons/weapons/knife_karambit.vnmskel"
        m_szName = "weapon_knife_karambit"
    }
```

- Add a new subclass entry (e.g., weapon_knife_karambit+1550) with m_szModel_AG2 (or m_szWorldModel if needed) pointing to your model path.
- Upload the model to workshop so the _c file exists (.vmdl_c) under your addon path.

```json
"Custom Weapon": {
        "karambit": {
          "karambit_custom": {
            "uniqueid": "karambitcustom",
            "type": "customweapon",
            "weapon": "weapon_knife:weapon_knife_karambit+1550",
            "price": "1000",
            "slot": "1"
          }
        }
    }
```

- In the store config, set weapon to the matching `base:subclass`.
- The plugin will then apply the subclass at runtime and the new model will appear.

---

### Inspiration
Approach based on the method described in:
https://github.com/exkludera-cssharp/equipments/issues/5#issuecomment-3603250775