### PR TITLE
refactor: Avoid heavy `Utilities.GetPlayers` in `OnTick` listener

### DIFF
--- a/Store/src/cs2-store.cs
+++ b/Store/src/cs2-store.cs
@@ -13,7 +13,7 @@ namespace Store;
 public class Store : BasePlugin, IPluginConfig<Item_Config>
 {
     public override string ModuleName => "Store";
-    public override string ModuleVersion => "v29";
+    public override string ModuleVersion => "v30";
     public override string ModuleAuthor => "schwarper";
 
     public Item_Config Config { get; set; } = new();

--- a/Store/src/cs2-store.cs
+++ b/Store/src/cs2-store.cs
@@ -21,6 +21,7 @@ public class Store : BasePlugin, IPluginConfig<Item_Config>
     public List<Store_Item> GlobalStorePlayerItems { get; set; } = [];
     public List<Store_Equipment> GlobalStorePlayerEquipments { get; set; } = [];
     public Dictionary<CCSPlayerController, PlayerTimer> GlobalDictionaryPlayer { get; set; } = [];
+    public CCSPlayerController?[] ActivePlayerSlots { get; set; } = new CCSPlayerController?[64];
     public int GlobalTickrate { get; set; } = 0;
     public static Store Instance { get; set; } = new();
     public Random Random { get; set; } = new();
@@ -45,6 +46,7 @@ public class Store : BasePlugin, IPluginConfig<Item_Config>
                 if (player.IsBot)
                     continue;
 
+                ActivePlayerSlots[player.Slot] = player;
                 Database.LoadPlayer(player);
                 MenuManager.CloseActiveMenu(player);
             }

--- a/Store/src/event/event.cs
+++ b/Store/src/event/event.cs
@@ -116,11 +116,9 @@ public static class Event
 
     public static void OnTick()
     {
-        List<CCSPlayerController> players = Utilities.GetPlayers();
-
-        foreach (CCSPlayerController player in players)
+        foreach (var player in Instance.ActivePlayerSlots)
         {
-            if (!player.PawnIsAlive) continue;
+            if (player is null || !player.IsValid || !player.PawnIsAlive) continue;
 
             Item_Bunnyhop.OnTick(player);
         }
@@ -131,8 +129,10 @@ public static class Event
 
         Instance.GlobalTickrate = 0;
 
-        foreach (CCSPlayerController player in players)
+        foreach (var player in Instance.ActivePlayerSlots)
         {
+            if (player is null || !player.IsValid) continue;
+
             Item_Trail.OnTick(player);
             Item_ColoredSkin.OnTick(player);
         }
@@ -172,6 +172,7 @@ public static class Event
         }
 
         Instance.GlobalGiftTimeout[player] = 0;
+        Instance.ActivePlayerSlots[player.Slot] = player;
 
         Database.UpdateVip(player);
 
@@ -197,6 +198,7 @@ public static class Event
         Instance.GlobalStorePlayerItems.RemoveAll(i => i.SteamID == player.SteamID);
         Instance.GlobalStorePlayerEquipments.RemoveAll(e => e.SteamID == player.SteamID);
         Instance.GlobalGiftTimeout.Remove(player);
+        Instance.ActivePlayerSlots[player.Slot] = null;
 
         return HookResult.Continue;
     }


### PR DESCRIPTION
`Utilities.GetPlayers` is heavy on allocation and is being called 64 times a second in the on-tick handler. Instead an array of players indexed by slot is maintained that is very cheap to traverse.

It might also be worthwhile to move the latter part of on-tick into a timer. Perhaps all these module on-ticks should not be this deeply intertwined into the core.